### PR TITLE
'News' button is broken

### DIFF
--- a/themes/pelican-bootstrap3-kepler/templates/base.html
+++ b/themes/pelican-bootstrap3-kepler/templates/base.html
@@ -156,7 +156,7 @@ in August 2015, using pelican-bootstrap and flatly.
             <ul class="nav navbar-nav">
                 {% for title, link in MENUITEMS %}
                     {% if link is string %}
-                        <li><a href="{{ link }}">{{ title }}</a></li>
+                        <li><a href="{{ SITEURL }}/{{ link }}">{{ title }}</a></li>
                     {% else %}
                         <li class="dropdown">
                             <a href="#" class="dropdown-toggle" data-toggle="dropdown">{{ title }} <b class="caret"></b></a>


### PR DESCRIPTION
Over at
   https://heasarc.gsfc.nasa.gov/cgi-bin/tess/webtess/wtm.py
the `News` button in the navbar is broken.  I suspect this will fix it.  (I did not test.)